### PR TITLE
Replace 1-matrix with identity matrix

### DIFF
--- a/python/pipeline_utils.py
+++ b/python/pipeline_utils.py
@@ -73,11 +73,11 @@ def get_metadata(image_path):
         metadata['as_shot_neutral'] = [1, 1, 1]
         print("AsShotNeutral is None; using [1, 1, 1]")
     if metadata['color_matrix_1'] is None:
-        metadata['color_matrix_1'] = [1] * 9
-        print("ColorMatrix1 is None; using [1, 1, 1, 1, 1, 1, 1, 1, 1]")
+        metadata['color_matrix_1'] = np.eye(3)
+        print("ColorMatrix1 is None; using\n" + str(metadata['color_matrix_1']))
     if metadata['color_matrix_2'] is None:
-        metadata['color_matrix_2'] = [1] * 9
-        print("ColorMatrix2 is None; using [1, 1, 1, 1, 1, 1, 1, 1, 1]")
+        metadata['color_matrix_2'] = np.eye(3)
+        print("ColorMatrix2 is None; using\n" + str(metadata['color_matrix_2']))
     if metadata['orientation'] is None:
         metadata['orientation'] = 0
         print("Orientation is None; using 0.")


### PR DESCRIPTION
If `color_matrix_1` or `color_matrix_2` can not be found, the 1-matrix is used instead:

https://github.com/AbdoKamel/simple-camera-pipeline/blob/26b4041640a4ee9589b3dfa80579d73feda6e02c/python/pipeline_utils.py#L75

This is not a good default value because it will raise `numpy.linalg.LinAlgError: Singular matrix` later in the pipeline:

https://github.com/AbdoKamel/simple-camera-pipeline/blob/26b4041640a4ee9589b3dfa80579d73feda6e02c/python/pipeline_utils.py#L341

The identity matrix is a better choice here.

The cause of the error was probably copy & paste from the previous check of `as_shot_neutral`:

https://github.com/AbdoKamel/simple-camera-pipeline/blob/26b4041640a4ee9589b3dfa80579d73feda6e02c/python/pipeline_utils.py#L73